### PR TITLE
[feature] PostResponse에 isExist 추가 및 빈 Post 객체 생성 방식 변경

### DIFF
--- a/src/main/java/com/sanbosillok/sanbosillokserver/api/post/dto/PostResponse.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/api/post/dto/PostResponse.java
@@ -14,14 +14,18 @@ public class PostResponse {
     private Long id;
     private String title;
     private String contents;
+    private String lastModifier;
     private PostStatus status;
     private LocalDateTime updatedAt;
+    private Boolean isExist;
 
     public PostResponse(Post post) {
         id = post.getId();
         title = post.getTitle();
         contents = post.getContents();
+        lastModifier = post.getLastModifier();
         status = post.getStatus();
         updatedAt = post.getUpdatedAt();
+        isExist = (id != null);
     }
 }

--- a/src/main/java/com/sanbosillok/sanbosillokserver/api/post/service/PostService.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/api/post/service/PostService.java
@@ -43,10 +43,6 @@ public class PostService {
     public PostResponse getPost(String title) {
         return new PostResponse(postRepository.findByTitle(title)
                     .orElse(Post.builder()
-                            .title(null)
-                            .contents(null)
-                            .lastModifier(null)
-                            .status(null)
                             .build()));
     }
 


### PR DESCRIPTION
### ✏️Describe
단일 Post를 조회하는 경우에 해당 Post가 없는 것이 에러가 아닌, 새로운 Post 생성으로 이어지는 조건이므로 별도 처리.
이때, 프론트엔드에서 분기 처리를 용이하게 하기 위해 PostResponse에 isExist 추가.
DTO 생성자에서 id 값을 기준으로 isExist값 초기화.

### 🚀Task
- [x] PostResponse에 isExist 추가
- [x] Service Layer의 단일 조회 로직에서 빈 객체 생성 방식 변경

### 🔥Related Issue
close #27 