### PR TITLE
[fix] 저장된 이미지 출력 시, 데이터가 깨지는 현상 해결

### DIFF
--- a/src/main/java/com/sanbosillok/sanbosillokserver/api/image/service/ImageService.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/api/image/service/ImageService.java
@@ -6,16 +6,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class ImageService {
 
-    public static final String BASE_PATH = "/home/image/";
+    public static final String BASE_PATH = "/home/ubuntu/image/";
 
     public ImagePathResponse upload(MultipartFile file) {
         String uuid = UUID.randomUUID().toString();
@@ -34,11 +35,11 @@ public class ImageService {
     }
 
     public byte[] getImage(String fileName) {
-        String path = BASE_PATH + fileName;
+        Path imagePath = Paths.get(BASE_PATH, fileName);
 
-        try (InputStream inputStream = new FileInputStream(path)) {
-            return inputStream.readAllBytes();
-        } catch (IOException e) {
+        try {
+            return Files.readAllBytes(imagePath);
+        }catch (IOException e) {
             throw new IllegalArgumentException("해당 파일이 존재하지 않습니다.");
         }
     }


### PR DESCRIPTION
### ✏️Describe
저장된 이미지 출력 시, 데이터가 깨지는 현상이 발생하여 binary파일을 직접 가져오는 메서드로 변경하였습니다.

### 🚀Task
- [x] getImage 메서드 변경

### 🔥Related Issue
close #36 