### PR TITLE
[fix] JwtTokenProvider Bean 등록

### DIFF
--- a/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/JwtTokenProvider.java
@@ -2,12 +2,14 @@ package com.sanbosillok.sanbosillokserver.config.jwt;
 
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
+@Component
 public class JwtTokenProvider {
 
     private final SecretKey secretKey;


### PR DESCRIPTION
### ✏️Describe
JwtTokenProvider를 SecurityConfig에서 사용할 수 있도록 Bean에 등록
`@Conponent` 를 사용

### 🚀Task
- [x] JwtTokenProvider Bean 등록


### 🔥Related Issue
close #7 