### PR TITLE
[refactor] logout 성공 handling 변경

### DIFF
--- a/src/main/java/com/sanbosillok/sanbosillokserver/config/SecurityConfig.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.web.cors.CorsConfiguration;
 
 import java.util.Arrays;
@@ -74,6 +75,10 @@ public class SecurityConfig {
 
                 //http basic 인증 방식 disable
                 .httpBasic(AbstractHttpConfigurer::disable)
+
+                // logout
+                .logout((logout) -> logout
+                        .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler()))
 
                 //경로별 인가 작업
                 .authorizeHttpRequests((auth) -> auth


### PR DESCRIPTION
### ✏️Describe
logout 성공 시, 기존 `/login?logout` 으로 redirecting 되던 것(Spring Security default)을 200 OK 반환으로 변경

### 🚀Task
- [x] logoutSuccessHandler 설정을 통해 성공 시 반환 값 설정 (redirect 보다 우선 적용)

### 🔥Related Issue
close #46 