### PR TITLE
[fix] 회원 가입 승인 시, 권한 수정이 안되는 에러 해결

### DIFF
--- a/src/main/java/com/sanbosillok/sanbosillokserver/api/member/service/MemberService.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/api/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.sanbosillok.sanbosillokserver.api.member.service;
 
+import com.sanbosillok.sanbosillokserver.api.member.domain.Member;
 import com.sanbosillok.sanbosillokserver.api.member.domain.MemberRole;
 import com.sanbosillok.sanbosillokserver.api.member.dto.MemberResponse;
 import com.sanbosillok.sanbosillokserver.api.member.repository.MemberRepository;
@@ -24,8 +25,10 @@ public class MemberService {
     }
 
     public void activateMember(Long id) {
-        memberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 회원 가입 신청이 존재하지 않습니다."))
-                .updateRole(MemberRole.ACTIVE);
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 회원 가입 신청이 존재하지 않습니다."));
+
+        member.updateRole(MemberRole.ACTIVE);
+        memberRepository.save(member);
     }
 }


### PR DESCRIPTION
### ✏️Describe
회원 가입 승인 시, 권한 수정이 안되는 에러가 발생하였습니다.
해당 객체를 수정한 후, save를 하지 않아 발생한 에러.
따라서 저장 로직을 추가했습니다.

### 🚀Task
- [x] activateMember 메서드에 save 로직 추가

### 🔥Related Issue
close #52 