### PR TITLE
[feature] refreshToken을 이용한 accessToken 재발급 API

### DIFF
--- a/src/main/java/com/sanbosillok/sanbosillokserver/api/auth/controller/TokenController.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/api/auth/controller/TokenController.java
@@ -1,0 +1,23 @@
+package com.sanbosillok.sanbosillokserver.api.auth.controller;
+
+import com.sanbosillok.sanbosillokserver.api.auth.dto.AccessTokenResponse;
+import com.sanbosillok.sanbosillokserver.api.auth.dto.RefreshTokenRequest;
+import com.sanbosillok.sanbosillokserver.api.auth.service.TokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/token")
+public class TokenController {
+    private final TokenService tokenService;
+
+    @GetMapping("/refresh")
+    public AccessTokenResponse getNewToken(@RequestBody @Valid RefreshTokenRequest refreshTokenRequest) {
+        return tokenService.reIssueAccessToken(refreshTokenRequest.getRefreshToken());
+    }
+}

--- a/src/main/java/com/sanbosillok/sanbosillokserver/api/auth/service/TokenService.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/api/auth/service/TokenService.java
@@ -1,0 +1,34 @@
+package com.sanbosillok.sanbosillokserver.api.auth.service;
+
+import com.sanbosillok.sanbosillokserver.api.auth.dto.AccessTokenResponse;
+import com.sanbosillok.sanbosillokserver.api.member.domain.Member;
+import com.sanbosillok.sanbosillokserver.api.member.repository.MemberRepository;
+import com.sanbosillok.sanbosillokserver.config.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    public AccessTokenResponse reIssueAccessToken(String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new IllegalArgumentException("토큰이 비어있습니다.");
+        }
+
+        if (jwtTokenProvider.isExpired(refreshToken)) {
+            throw new IllegalArgumentException("만료된 refresh token 입니다.");
+        }
+
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("잘못된 token 형식입니다."));
+
+        String username = member.getUsername();
+        String role = member.getRole().toString();
+
+        return new AccessTokenResponse(jwtTokenProvider.createAccessToken(username, role));
+    }
+}

--- a/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/JwtTokenProvider.java
@@ -14,6 +14,9 @@ public class JwtTokenProvider {
 
     private final SecretKey secretKey;
 
+    @Value("${jwt.refresh-token.expire-length}")
+    private Long refreshTokenExpireLength;
+
     @Value("${jwt.access-token.expire-length}")
     private Long accessTokenExpireLength;
 
@@ -31,13 +34,16 @@ public class JwtTokenProvider {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class).split("_")[1];
     }
 
+    public Long getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Long.class);
+    }
+
     public Boolean isExpired(String token) {
 
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(String username, String role) {
-
+    public String createAccessToken(String username, String role) {
         return Jwts.builder()
                 .claim("username", username)
                 .claim("role", role)
@@ -46,4 +52,14 @@ public class JwtTokenProvider {
                 .signWith(secretKey)
                 .compact();
     }
+
+    public String createRefreshToken(Long id) {
+        return Jwts.builder()
+                .claim("id", id)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpireLength))
+                .signWith(secretKey)
+                .compact();
+    }
+
 }

--- a/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/LoginFilter.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/LoginFilter.java
@@ -46,6 +46,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
 
+        Long id = customUserDetails.getId();
         String username = customUserDetails.getUsername();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
@@ -54,10 +55,11 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String role = auth.getAuthority();
 
-        String token = jwtTokenProvider.createJwt(username, role);
+        String refreshToken = jwtTokenProvider.createRefreshToken(id);
+        String accessToken = jwtTokenProvider.createAccessToken(username, role);
 
         response.setContentType("application/json");
-        response.getWriter().print(objectMapper.writeValueAsString(new LoginResponse(token, role)));
+        response.getWriter().print(objectMapper.writeValueAsString(new LoginResponse(refreshToken, accessToken, role)));
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,5 @@ jwt:
   secret: ${JWT_SECRET}
   access-token:
     expire-length: ${ACCESS_TOKEN_EXPIRED_TIME}
+  refresh-token:
+    expire-length: ${REFRESH_TOKEN_EXPIRED_TIME}


### PR DESCRIPTION
### ✏️Describe
refreshToken을 통해, accessToken을 재발급 받을 수 있는 API 구현

### 🚀Task
- [x] TokenController 작성
- [x] TokenService 작성
- [x] TokenProvider의 토큰 발급 메서드를 accessToken 발급 메서드와 refreshToken 발급 메서드로 분리
- [x] LoginFilter에 refreshToken 발급 로직 추가
- [x] application.yml에 refreshToken 만료 시간 설정

### 🔥Related Issue
close #56 