### PR TITLE
[feature] 인증/인가 관련 예외 처리

### DIFF
--- a/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package com.sanbosillok.sanbosillokserver.config.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Unauthorized user.\"}");
+    }
+}

--- a/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sanbosillok/sanbosillokserver/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.sanbosillok.sanbosillokserver.config.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Please send a valid token.\"}");
+    }
+}


### PR DESCRIPTION
### ✏️Describe
1. 사용자 정보(username, password)가 잘못된 경우
    - 401
2. accessToken이 잘못된 경우 (만료 or 잘못된 형식)
    - 401
    - error message: Please send a valid token.
3. accessToken이 잘못된 경우 (만료 or 잘못된 형식)
    - 403
    - error message: Unauthorized user.

### 🚀Task
- [x] AuthenticationEntryPoint 커스텀 구현
- [x] AccessDeniedHandler 커스텀 구현
- [x] SecurityConfig에서 커스텀 구현들 Bean 등록

### 🔥Related Issue
close #57 